### PR TITLE
Map Maker: search visibility, explained on the About page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this dataset repository will be documented here.
 - Map Maker boundary layers grouped by type: administrative (states, districts, sub-districts, blocks) and electoral (parliamentary and assembly constituencies), built from the LGD release files
 - Map Maker: template CSV with region codes that matches exactly when filled in and uploaded; sheet and value-column pickers for workbooks with several; project files that save and reopen a whole map; level switches to match the names pasted
 - `scripts/build-map-layers.py` to regenerate the simplified TopoJSON layers from the LGD release files
+- Map Maker: info link to a new About-page section, structured data and a link-preview image
+
 
 ## [1.0.0] - 2026-03-07
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@ A unified, structured collection of India's openly-licensed geospatial data — 
 
 Browse and download at **[india-geodata](https://yashveeeeeeer.github.io/india-geodata)**
 
-Make your own map from a spreadsheet with the **[India Map Maker](https://yashveeeeeeer.github.io/india-geodata/maps/)** — states, districts, sub-districts, blocks, parliamentary and assembly constituencies; free, no watermark, runs entirely in the browser.
+---
+
+## India Map Maker — free online map maker for India
+
+**[Open the map maker](https://yashveeeeeeer.github.io/india-geodata/maps/)** · paste a spreadsheet, get a coloured map. No sign-up, no watermark, nothing is uploaded.
+
+[![India Map Maker: literacy rate by state, 2011](docs/assets/img/map-maker.png)](https://yashveeeeeeer.github.io/india-geodata/maps/)
+
+- Map all of India, one state or one district by **state, district, sub-district, block, parliamentary or assembly constituency**
+- Paste from Excel or Google Sheets, or drop a CSV / Excel file; misspelt names are flagged and fixable, or use the template CSV with official codes
+- Colour palettes, legend, labels, title and source text, zoom and pan
+- Export **PNG, SVG, PDF** and CSV, or save a project file to reopen later
+- Plain HTML, CSS and JavaScript in [`docs/maps/`](docs/maps/) and [`docs/assets/js/`](docs/assets/js/); boundaries built by [`scripts/build-map-layers.py`](scripts/build-map-layers.py)
 
 ---
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,8 +8,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=8">
-  {% if page.url contains "/maps/" %}<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/maps.css?v={{ site.time | date: '%s' }}">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=9">
+  {% if page.url contains "/maps/" %}<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/maps.css?v={{ site.time | date: '%s' }}">
   <link rel="preload" as="fetch" crossorigin="anonymous" href="{{ site.baseurl }}/maps/data/districts.topo.json?v={{ site.time | date: '%s' }}">{% endif %}
 </head>
 <body{% if page.url contains "/maps/" %} class="page-maps"{% endif %}>

--- a/docs/about.html
+++ b/docs/about.html
@@ -16,6 +16,20 @@ description: "India Geodata is compiled by Yashveer Singh — a believer in open
     </p>
   </section>
 
+  <section class="about-maps" id="map-maker">
+    <h2>India Map Maker</h2>
+    <h3>What is India Map Maker?</h3>
+    <p>A free online map maker for India, built on the boundaries in this collection. Paste or upload a spreadsheet and it colours a map of India by state, district, sub-district, block, parliamentary constituency or assembly constituency. It runs in your browser and nothing is uploaded. <a href="{{ site.baseurl }}/maps/">Open the map maker</a>.</p>
+    <h3>What does it cost?</h3>
+    <p>Nothing. There is no sign-up, no watermark and no paid tier. The code is open source and the boundaries are open government data.</p>
+    <h3>What data can I map?</h3>
+    <p>Any table with a name column and a number column: literacy rates, population, election results, sales by district. Misspelt names are flagged so you can fix them on the spot, or download the template CSV, fill in the value column and upload it back.</p>
+    <h3>Can I map a single state or district?</h3>
+    <p>Yes. Choose all of India, one state or one district, then divide it by any level: 36 states and union territories, 785 districts, sub-districts, blocks, 543 parliamentary constituencies or 4,177 assembly constituencies.</p>
+    <h3>What can I export?</h3>
+    <p>PNG at two sizes, SVG for editing in Illustrator or Inkscape, PDF for print, the data as CSV, and a project file you can reopen later.</p>
+  </section>
+
   <section class="about-connect">
     <h2>Connect</h2>
     <p>Know of a GIS or geodata dataset that should be here? Have feedback, found an error, or just want to say hi?</p>
@@ -59,3 +73,58 @@ description: "India Geodata is compiled by Yashveer Singh — a believer in open
   </section>
 
 </div>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "@id": "{{ site.url }}{{ site.baseurl }}/about#map-maker",
+  "about": {
+    "@type": "WebApplication",
+    "name": "India Map Maker",
+    "url": "{{ site.url }}{{ site.baseurl }}/maps/"
+  },
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is India Map Maker?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A free online map maker for India, built on the boundaries in this collection. Paste or upload a spreadsheet and it colours a map of India by state, district, sub-district, block, parliamentary constituency or assembly constituency. It runs in your browser and nothing is uploaded."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does it cost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nothing. There is no sign-up, no watermark and no paid tier. The code is open source and the boundaries are open government data."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What data can I map?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Any table with a name column and a number column: literacy rates, population, election results, sales by district. Misspelt names are flagged so you can fix them on the spot, or download the template CSV, fill in the value column and upload it back."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I map a single state or district?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Choose all of India, one state or one district, then divide it by any level: 36 states and union territories, 785 districts, sub-districts, blocks, 543 parliamentary constituencies or 4,177 assembly constituencies."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What can I export?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "PNG at two sizes, SVG for editing in Illustrator or Inkscape, PDF for print, the data as CSV, and a project file you can reopen later."
+      }
+    }
+  ]
+}
+</script>

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -386,6 +386,7 @@ main { flex: 1; }
   padding-bottom: 6px;
   border-bottom: 1px solid var(--color-border);
 }
+.about-page h3 { font-size: 1rem; font-weight: 600; margin: 18px 0 6px; }
 .about-page p { margin-bottom: 12px; font-size: 0.95rem; line-height: 1.7; color: var(--color-text); }
 .about-page a { color: var(--color-accent); text-decoration: underline; text-decoration-color: rgba(245,158,11,0.35); text-underline-offset: 2px; }
 .about-page a:hover { text-decoration-color: var(--color-accent); }

--- a/docs/assets/css/maps.css
+++ b/docs/assets/css/maps.css
@@ -8,6 +8,10 @@
 
 .maps-intro { margin-bottom: 16px; }
 .maps-intro h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.01em; }
+.maps-title { display: flex; align-items: center; gap: 10px; }
+.info-link { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; border: 1.5px solid var(--color-muted); color: var(--color-muted); flex: none; }
+.info-link::before { content: ""; position: absolute; inset: -10px; }   /* 40px touch target, nothing visible */
+.info-link:hover, .info-link:focus-visible { border-color: var(--color-accent); color: var(--color-accent); }
 
 .maps-layout { display: grid; grid-template-columns: 320px minmax(0, 1fr); gap: 20px; align-items: start; }
 

--- a/docs/maps/index.html
+++ b/docs/maps/index.html
@@ -1,8 +1,11 @@
 ---
 layout: default
-title: "India Map Maker"
-description: "Turn a spreadsheet into a map of India by state, district, sub-district, block or constituency, in your browser. Free and open, no sign-up, no watermark. Export PNG, SVG or PDF."
-image: /assets/img/map-maker.png
+title: "India Map Maker: Free Online Map Maker for India"
+description: "Free online map maker for India. Paste a spreadsheet to colour a map by state, district, block or constituency. No sign-up, no watermark. Export PNG, SVG or PDF."
+image:
+  path: /assets/img/map-maker.png
+  width: 1200
+  height: 630
 permalink: /maps/
 ---
 
@@ -10,7 +13,10 @@ permalink: /maps/
   <noscript><p class="status">The map maker needs JavaScript.</p></noscript>
 
   <div class="maps-intro">
-    <h1>India Map Maker</h1>
+    <div class="maps-title">
+      <h1>India Map Maker</h1>
+      <a class="info-link" href="{{ site.baseurl }}/about#map-maker" aria-label="About India Map Maker" title="About this tool"><svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true" focusable="false"><circle cx="5" cy="2.1" r="1.1" fill="currentColor"/><path d="M5 4.4v4.2" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></a>
+    </div>
   </div>
 
   <div class="maps-layout">
@@ -284,6 +290,73 @@ permalink: /maps/
 
 <div class="map-tip" id="mapTip"></div>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebApplication",
+      "@id": "{{ site.url }}{{ site.baseurl }}/maps/#app",
+      "name": "India Map Maker",
+      "alternateName": "Free online map maker for India",
+      "url": "{{ site.url }}{{ site.baseurl }}/maps/",
+      "description": "{{ page.description }}",
+      "applicationCategory": "DesignApplication",
+      "applicationSubCategory": "Map maker",
+      "operatingSystem": "Any",
+      "browserRequirements": "Requires JavaScript",
+      "isAccessibleForFree": true,
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "INR"
+      },
+      "inLanguage": "en",
+      "softwareVersion": "1.1.0",
+      "datePublished": "2026-09-09",
+      "image": "{{ site.url }}{{ site.baseurl }}/assets/img/map-maker.png",
+      "screenshot": "{{ site.url }}{{ site.baseurl }}/assets/img/map-maker.png",
+      "featureList": [
+        "Map of India by state, district, sub-district, block, parliamentary or assembly constituency",
+        "Paste from Excel or Google Sheets, or upload CSV and Excel files",
+        "Automatic name matching with fixes for misspelt names",
+        "Colour palettes, legend, labels, title, subtitle and source text",
+        "Export PNG, SVG, PDF and CSV without a watermark",
+        "Runs in the browser, no upload, no sign-up"
+      ],
+      "author": {
+        "@type": "Person",
+        "name": "Yashveer Singh",
+        "url": "https://github.com/yashveeeeeeer"
+      },
+      "license": "https://github.com/yashveeeeeeer/india-geodata/blob/main/LICENSE",
+      "sameAs": "https://github.com/yashveeeeeeer/india-geodata",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "India Geodata",
+        "url": "{{ site.url }}{{ site.baseurl }}/"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "India Geodata",
+          "item": "{{ site.url }}{{ site.baseurl }}/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "India Map Maker",
+          "item": "{{ site.url }}{{ site.baseurl }}/maps/"
+        }
+      ]
+    }
+  ]
+}
+</script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/topojson/3.0.2/topojson.min.js" integrity="sha384-9dCJK6nh7skY14HrcvlLYlFga9/MehJjL9ONWRflmiXNRuf8p2jiF4Y5PR881PTq" crossorigin="anonymous"></script>
 <script src="{{ site.baseurl }}/assets/js/maps-core.js?v={{ site.time | date: '%s' }}"></script>


### PR DESCRIPTION
Makes the map maker page findable for searches like "free online map maker for India" without adding copy to the map page.

- Page title, meta description, link-preview image size, preconnect to the script CDN
- WebApplication and breadcrumb structured data on the map page
- A small circled i beside the heading links to a new India Map Maker section on the About page with five short answers, mirrored as FAQ structured data
- README section for the map maker with the screenshot

Verified in the local harness on desktop and phone widths: the map page layout is unchanged apart from the icon, the icon sits centred on the heading line, the About section renders in the page's existing style, structured data parses, the app boots with no console errors, tests pass.