### PR TITLE
Map Maker: one CSV button instead of two

### DIFF
--- a/docs/assets/js/maps.js
+++ b/docs/assets/js/maps.js
@@ -643,7 +643,7 @@
     current.features.slice().sort(function (a, b) { return a.properties.name.localeCompare(b.properties.name); }).forEach(function (f) {
       var p = f.properties;
       var v = values[current.level][f.id];
-      rows.push([p.name, current.level === 'states' ? '' : parentOf(p), p.lgd, v == null ? '' : v]);
+      rows.push([csvSafe(p.name), csvSafe(current.level === 'states' ? '' : parentOf(p)), p.lgd, v == null ? '' : csvSafe(v)]);
     });
     download(new Blob(['\ufeff' + d3.csvFormatRows(rows)], { type: 'text/csv;charset=utf-8' }), (regionLabel() + ' ' + current.level).toLowerCase().replace(/[^a-z0-9]+/g, '-') + '-template.csv');
   });
@@ -1691,17 +1691,6 @@
     fr.readAsText(file);
   }
 
-  function exportCsv() {
-    var vals = values[current.level];
-    var rows = [['name', 'parent', 'lgd_code', 'value']];
-    current.features.forEach(function (f) {
-      var p = f.properties;
-      var v = vals[f.id];
-      rows.push([csvSafe(p.name), csvSafe(current.level === 'states' ? '' : parentOf(p)), p.lgd, v == null ? '' : csvSafe(v)]);
-    });
-    download(new Blob(['\ufeff' + d3.csvFormatRows(rows)], { type: 'text/csv;charset=utf-8' }), slug() + '.csv');
-  }
-
   document.querySelectorAll('[data-export]').forEach(function (btn) {
     btn.addEventListener('click', function () {
       if (!svgNode) return;
@@ -1711,7 +1700,6 @@
       else if (kind === 'project') exportProject();
       else if (kind === 'svg') download(new Blob([svgString()], { type: 'image/svg+xml' }), slug() + '.svg');
       else if (kind === 'pdf') exportPdf();
-      else if (kind === 'csv') exportCsv();
     });
   });
 

--- a/docs/maps/index.html
+++ b/docs/maps/index.html
@@ -66,7 +66,6 @@ permalink: /maps/
             <button class="btn-plain secondary" id="clearData" type="button">Clear</button>
             <button class="btn-plain secondary" id="sampleData" type="button">Sample</button>
             <button class="btn-plain secondary" id="regionList" type="button" title="Fill the data in the existing CSV to show it over the map">Template CSV</button>
-            <button class="btn-plain secondary" data-export="csv" type="button" title="Download the values on the map as CSV">Data CSV</button>
           </div>
           <div class="status" id="matchStatus" role="status"></div>
           <div class="unmatched" id="unmatched"></div>


### PR DESCRIPTION
Template CSV and Data CSV produced the same four columns for the same regions, differing only in sort order and filename. This keeps Template CSV, which serves as both the blank template and the export of what is on the map, and carries over the cell quoting for values that start with a formula character.

Verified in the local harness: button gone, template lists all 36 states, text values such as `=SUM(1)` are written as `'=SUM(1)`, no console errors, 19 Node tests pass.