### PR TITLE
About page: fold the map maker answers behind Read more

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=10">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=11">
   {% if page.url contains "/maps/" %}<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/maps.css?v={{ site.time | date: '%s' }}">
   <link rel="preload" as="fetch" crossorigin="anonymous" href="{{ site.baseurl }}/maps/data/districts.topo.json?v={{ site.time | date: '%s' }}">{% endif %}

--- a/docs/about.html
+++ b/docs/about.html
@@ -20,14 +20,17 @@ description: "India Geodata is compiled by Yashveer Singh — a believer in open
     <h2>India Map Maker</h2>
     <h3>What is India Map Maker?</h3>
     <p>A free online map maker for India, built on the boundaries in this collection. Paste or upload a spreadsheet and it colours a map of India by state, district, sub-district, block, parliamentary constituency or assembly constituency. It runs in your browser and nothing is uploaded. <a href="{{ site.baseurl }}/maps/">Open the map maker</a>.</p>
-    <h3>What does it cost?</h3>
-    <p>Nothing. There is no sign-up, no watermark and no paid tier. The code is open source and the boundaries are open government data.</p>
-    <h3>What data can I map?</h3>
-    <p>Any table with a name column and a number column: literacy rates, population, election results, sales by district. Misspelt names are flagged so you can fix them on the spot, or download the template CSV, fill in the value column and upload it back.</p>
-    <h3>Can I map a single state or district?</h3>
-    <p>Yes. Choose all of India, one state or one district, then divide it by any level: 36 states and union territories, 785 districts, sub-districts, blocks, 543 parliamentary constituencies or 4,177 assembly constituencies.</p>
-    <h3>What can I export?</h3>
-    <p>PNG at two sizes, SVG for editing in Illustrator or Inkscape, PDF for print, the data as CSV, and a project file you can reopen later.</p>
+    <details class="about-more">
+      <summary><span class="more">Read more</span><span class="less">Read less</span></summary>
+      <h3>What does it cost?</h3>
+      <p>Nothing. There is no sign-up, no watermark and no paid tier. The code is open source and the boundaries are open government data.</p>
+      <h3>What data can I map?</h3>
+      <p>Any table with a name column and a number column: literacy rates, population, election results, sales by district. Misspelt names are flagged so you can fix them on the spot, or download the template CSV, fill in the value column and upload it back.</p>
+      <h3>Can I map a single state or district?</h3>
+      <p>Yes. Choose all of India, one state or one district, then divide it by any level: 36 states and union territories, 785 districts, sub-districts, blocks, 543 parliamentary constituencies or 4,177 assembly constituencies.</p>
+      <h3>What can I export?</h3>
+      <p>PNG at two sizes, SVG for editing in Illustrator or Inkscape, PDF for print, the data as CSV, and a project file you can reopen later.</p>
+    </details>
   </section>
 
   <section class="about-connect">

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -387,7 +387,12 @@ main { flex: 1; }
   border-bottom: 1px solid var(--color-border);
 }
 .about-page h3 { font-size: 1rem; font-weight: 600; margin: 18px 0 6px; }
-#map-maker { scroll-margin-top: 76px; }   /* land below the sticky header when linked from the map maker */
+#map-maker { scroll-margin-top: 76px; }
+.about-more > summary { display: inline-block; list-style: none; cursor: pointer; color: var(--color-accent); font-size: 0.95rem; text-decoration: underline; text-decoration-color: rgba(245,158,11,0.35); text-underline-offset: 2px; margin: 2px 0 12px; }
+.about-more > summary::-webkit-details-marker { display: none; }
+.about-more > summary:hover { text-decoration-color: var(--color-accent); }
+.about-more > summary:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; border-radius: 2px; }
+.about-more[open] > summary .more, .about-more:not([open]) > summary .less { display: none; }   /* land below the sticky header when linked from the map maker */
 .about-page p { margin-bottom: 12px; font-size: 0.95rem; line-height: 1.7; color: var(--color-text); }
 .about-page a { color: var(--color-accent); text-decoration: underline; text-decoration-color: rgba(245,158,11,0.35); text-underline-offset: 2px; }
 .about-page a:hover { text-decoration-color: var(--color-accent); }


### PR DESCRIPTION
Only the heading, the first question and its paragraph show by default; the other four answers open in place behind a Read more link styled like the page's other links, and it flips to Read less when open. No script, plain details/summary. Checked in the local harness.