### PR TITLE
Map Maker: plain heading, fewer panels open, remembered panel state

### DIFF
--- a/docs/assets/css/maps.css
+++ b/docs/assets/css/maps.css
@@ -8,10 +8,6 @@
 
 .maps-intro { margin-bottom: 16px; }
 .maps-intro h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.01em; }
-.maps-title { display: flex; align-items: center; gap: 10px; }
-.info-link { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; border: 1.5px solid var(--color-muted); color: var(--color-muted); flex: none; }
-.info-link::before { content: ""; position: absolute; inset: -10px; }   /* 40px touch target, nothing visible */
-.info-link:hover, .info-link:focus-visible { border-color: var(--color-accent); color: var(--color-accent); }
 
 .maps-layout { display: grid; grid-template-columns: 320px minmax(0, 1fr); gap: 20px; align-items: start; }
 

--- a/docs/assets/js/maps.js
+++ b/docs/assets/js/maps.js
@@ -1933,6 +1933,23 @@
   syncUi();
   setZoom(view.k, true);
   renderAssetList();
+  // Panels: Region and Data start open; each browser remembers what the user opened or closed
+  var PANEL_KEY = 'igd-mapmaker-panels';
+  (function () {
+    var saved = {};
+    try { saved = JSON.parse(localStorage.getItem(PANEL_KEY)) || {}; } catch (e) { saved = {}; }
+    document.querySelectorAll('.maps-side details.panel').forEach(function (p) {
+      var sum = p.querySelector('summary');
+      var key = sum ? sum.textContent.trim() : '';
+      if (!key) return;
+      if (Object.prototype.hasOwnProperty.call(saved, key)) p.open = !!saved[key];
+      p.addEventListener('toggle', function () {
+        saved[key] = p.open;
+        try { localStorage.setItem(PANEL_KEY, JSON.stringify(saved)); } catch (e) { /* storage blocked */ }
+      });
+    });
+  })();
+
   Promise.all([loadLayer('states'), loadLayer(ui.level.value)]).then(function (res) {
     populateStates(res[0]);
     ui.regionState.value = region.state;

--- a/docs/maps/index.html
+++ b/docs/maps/index.html
@@ -13,10 +13,7 @@ permalink: /maps/
   <noscript><p class="status">The map maker needs JavaScript.</p></noscript>
 
   <div class="maps-intro">
-    <div class="maps-title">
-      <h1>India Map Maker</h1>
-      <a class="info-link" href="{{ site.baseurl }}/about#map-maker" aria-label="About India Map Maker" title="About this tool"><svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true" focusable="false"><circle cx="5" cy="2.1" r="1.1" fill="currentColor"/><path d="M5 4.4v4.2" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg></a>
-    </div>
+    <h1>India Map Maker</h1>
   </div>
 
   <div class="maps-layout">
@@ -86,7 +83,7 @@ permalink: /maps/
         </div>
       </details>
 
-      <details class="panel" open>
+      <details class="panel">
         <summary>Colours</summary>
         <div class="panel-body">
           <div class="field">
@@ -196,7 +193,7 @@ permalink: /maps/
         </div>
       </details>
 
-      <details class="panel" open>
+      <details class="panel">
         <summary>Title &amp; text</summary>
         <div class="panel-body">
           <div class="btn-row">
@@ -262,7 +259,7 @@ permalink: /maps/
         </div>
       </details>
 
-      <details class="panel" open>
+      <details class="panel">
         <summary>Export</summary>
         <div class="panel-body">
           <div class="btn-row" id="exportRow">


### PR DESCRIPTION
- Removes the circled i beside the heading; the About page keeps its map maker section
- Only Region and Data start open, so a first visit still shows where to paste data; Colours, Title & text and Export start closed
- Each browser remembers which panels the user opened or closed

Checked in the local harness: defaults, persistence across reload, no console errors, tests pass.